### PR TITLE
minZoomLevel angeben um zoom reset beim manuellen Etappen Screen zu verhindern

### DIFF
--- a/components/Map/MapWithMarkers.tsx
+++ b/components/Map/MapWithMarkers.tsx
@@ -114,6 +114,7 @@ function MapWithMarkers({
           animationDuration={0}
           heading={heading}
           pitch={pitch}
+          minZoomLevel={0.1}
         />
         {/** Marker component for the start point, if the start coordinate is set. */}
         {startMarkerCoordinate && (


### PR DESCRIPTION
- [ ] Wenn nötig, refactored? (Pfadfinderregel)
- [ ] Tests ausreichend vorhanden?
- [ ] Code ausreichend kommentiert / dokumentiert?
- [ ] Dark-Mode beachtet?
- [x] PR in Discord gepostet?

Wenn die Camera einen zoomLevel von 0 bekommt dann nutzt sie das default zoomLevel 5 (keine Ahnung warum das so ist, wahrscheinlich ein Bug von MapBox). Deshalb habe ich das minZoomLevel jetzt auf 0.1 gesetzt.