### PR TITLE
use UserLocation speed in LiveStats

### DIFF
--- a/app/(tabs)/(home)/index.tsx
+++ b/app/(tabs)/(home)/index.tsx
@@ -62,6 +62,8 @@ export default function HomeScreen() {
   const [buttonState, setButtonState] = useState(ButtonStates.NotCycling);
   const [userCentered, setUserCentered] = useState(true); // Status: Ist die Kamera grade auf dem User zentriert?
 
+  const [userLocation, setUserLocation] = useState<MapboxGL.Location>();
+
   const camera = useRef<Camera>(null);
   const buttonIconSize = 60;
 
@@ -232,12 +234,18 @@ export default function HomeScreen() {
             ref={camera}
           />
           {/* Blauer Punkt */}
-          <MapboxGL.UserLocation androidRenderMode="gps" />
+          <MapboxGL.UserLocation
+            androidRenderMode="gps"
+            onUpdate={setUserLocation}
+          />
         </MapboxGL.MapView>
       </Layout>
-      {activeStage && (
+      {activeStage && userLocation && (
         <View style={styles.statisticsBox}>
-          <MapStatisticsBox stage={activeStage} />
+          <MapStatisticsBox
+            stage={activeStage}
+            speed={userLocation.coords.speed}
+          />
         </View>
       )}
       <View

--- a/components/Statistics/LiveStats.tsx
+++ b/components/Statistics/LiveStats.tsx
@@ -8,40 +8,8 @@ import { Stage } from "@/database/model/model";
 import { withObservables } from "@nozbe/watermelondb/react";
 import customStyles from "@/constants/styles";
 import IconStat from "@/components/Statistics/IconStat";
-import React, { useEffect, useState } from "react";
-import * as Location from "expo-location";
-import { LocationSubscription } from "expo-location";
-import { msToKmh } from "@/utils/unitUtils";
 
-function MapStatisticsBox({ stage }: { stage: Stage }) {
-  const [speed, setSpeed] = useState("0"); // Speed in meters/second
-
-  useEffect(() => {
-    let subscription: LocationSubscription;
-
-    const startLocationSubscription = async () => {
-      subscription = await Location.watchPositionAsync(
-        {
-          accuracy: Location.Accuracy.High,
-          timeInterval: 1000,
-          distanceInterval: 1,
-        },
-        (location) => {
-          const speed = location.coords.speed || 0;
-          setSpeed(msToKmh(speed).toFixed(1));
-        },
-      );
-    };
-
-    startLocationSubscription();
-
-    return () => {
-      if (subscription) {
-        subscription.remove();
-      }
-    };
-  }, []);
-
+function MapStatisticsBox({ stage, speed }: { stage: Stage; speed: number }) {
   return (
     <Card
       style={{

--- a/components/Statistics/LiveStats.tsx
+++ b/components/Statistics/LiveStats.tsx
@@ -49,7 +49,7 @@ function MapStatisticsBox({ stage, speed }: { stage: Stage; speed: number }) {
           iconWidth={30}
           iconHeight={30}
         >
-          {speed} km/h
+          {speed.toFixed(2)} km/h
         </IconStat>
       </View>
     </Card>


### PR DESCRIPTION
- [x] Wenn nötig, refactored? (Pfadfinderregel)
- [ ] Tests ausreichend vorhanden?
- [ ] Code ausreichend kommentiert / dokumentiert?
- [ ] Dark-Mode beachtet?
- [ ] PR in Discord gepostet?

LiveStats macht jetzt nicht mehr selber eine GPS Abfrage für die aktuelle Geschwindigkeit, sondern bekommt diese von der UserLocation. Das hat den Vorteil, dass sich die Geschwindigkeit öfter aktualisiert und es performanter ist, da keine zusätzliche Standortabfrage gemacht werden muss.